### PR TITLE
API v2 でツイート検索ベースの返信機能を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@
 | ACCOUNT_NAME         | はい                                                | Twitter アカウント名 (@の後の文字列)                     |
 | ENVIRONMENT_NAME     | いいえ(TWITTER_API_VERSION が 1 が 1C の時のみ必要) | dev environment の名前 (Premium Search API 用)           |
 | LIST_SLUG            | いいえ(TWITTER_API_VERSION が 1 が 1C の時のみ必要) | しゃろほー集計用に作ったリスト名                         |
-| TWITTER_BEARER_TOKEN | いいえ(TWITTER_API_VERSION が 2 の時のみ必要)       | Twitter API 管理画面から取得                             |
 | SYAROHO_LIST_ID      | いいえ(TWITTER_API_VERSION が 2 の時のみ必要)       | しゃろほー集計用に作ったリストID                         |
 | TWITTER_PASSWORD     | いいえ(TWITTER_API_VERSION が 1C の時のみ必要)      | Twitter アカウントのログインパスワード                   |
 | STORAGE              | はい                                                | local or s3                                              |

--- a/local.env.template
+++ b/local.env.template
@@ -13,7 +13,6 @@ ENVIRONMENT_NAME=  # Premium Search で使う dev environment 名
 LIST_SLUG=  # しゃろほー用リスト名
 
 # API v2 の場合
-TWITTER_BEARER_TOKEN=
 SYAROHO_LIST_ID=
 
 # API v1C (cookie を使用するライブラリで認証)の場合

--- a/src/syaroho_rating/consts.py
+++ b/src/syaroho_rating/consts.py
@@ -17,7 +17,6 @@ ACCOUNT_NAME = os.environ["ACCOUNT_NAME"]
 ENVIRONMENT_NAME = os.environ.get("ENVIRONMENT_NAME")
 LIST_SLUG = os.environ.get("LIST_SLUG")
 # APIv2
-BEARER_TOKEN = os.environ.get("TWITTER_BEARER_TOKEN")
 SYAROHO_LIST_ID = os.environ.get("SYAROHO_LIST_ID")
 # APIv1C
 TWITTER_PASSWORD = os.environ.get("TWITTER_PASSWORD")


### PR DESCRIPTION
## 内容

- API v2 でツイート検索ベースの返信機能を実装
- リストが空のときに落ちるバグが直ってなかったので修正
- ストリーミングを使わなくなったことで `BEARER_TOKEN` が不要になったので削除

## 関連

#29 
#32 